### PR TITLE
Rexcpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 dl
 *.exe
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -13,17 +13,14 @@ APP_VERSION := $(shell git describe --long 2>&-)
 
 # optional configurables
 #FB100_ROM := Brother_FB-100.rom # exists but not used
-TPDD2_ROM := TANDY_26-3814.rom
+#TPDD2_ROM := TANDY_26-3814.rom  # exists and is used
 #DEFAULT_BASIC_BYTE_MS := 8  # ms per byte in bootstrap
 #DEFAULT_MODEL := 1          # 1=tpdd1  2=tpdd2  (TS-DOS directory support requires tpdd1)
 #DEFAULT_OPERATION_MODE := 1 # 0=FDC-mode 1=Operation-mode
 #DEFAULT_BAUD := 19200
 #DEFAULT_RTSCTS := false
 #DEFAULT_UPCASE := false
-#DEFAULT_PROFILE := "k85" # k85 = Floppy/TS-DOS/etc - 6.2, dme, magic files
-#DEFAULT_BASELEN := 6    # default 6.2 filenames compatible with Floppy/TS-DOS/etc.
-#DEFAULT_EXTLEN := 2
-#DEFAULT_ATTR := 0x46   # default attribute 'F' compatible with Floppy/TS-DOS/etc.
+#DEFAULT_PROFILE := "k85" # k85 = Floppy/TS-DOS/etc - 6.2, padded, F, dme, magic files
 #RAW_ATTR := 0x20       # attr for "raw" mode, drive firmware fills unused fields with 0x20
 #DEFAULT_TILDES := true
 #XATTR_NAME := pdd.attr
@@ -101,11 +98,16 @@ DEFS = \
 	-DAPP_VERSION=\"$(APP_VERSION)\" \
 	-DAPP_LIB_DIR=\"$(APP_LIB_DIR)\" \
 	-DTTY_PREFIX=\"$(TTY_PREFIX)\" \
-	-DTPDD2_ROM=\"$(TPDD2_ROM)\" \
 	-DUSE_XATTR \
 #	-DPRINT_8BIT \
 #	-DNADSBOX_EXTENSIONS \
 
+#ifdef TPDD1_ROM
+#	DEFS += -DTPDD1_ROM=\"$(TPDD1_ROM)\"
+#endif
+ifdef TPDD2_ROM
+	DEFS += -DTPDD2_ROM=\"$(TPDD2_ROM)\"
+endif
 ifdef TSDOS_ROOT_LABEL
 	DEFS += -DTSDOS_ROOT_LABEL=\"$(TSDOS_ROOT_LABEL)\"
 endif
@@ -127,17 +129,11 @@ endif
 ifdef DEFAULT_RTSCTS
 	DEFS += -DDEFAULT_RTSCTS=$(DEFAULT_RTSCTS)
 endif
-ifdef DEFAULT_UPCASE
-	DEFS += -DDEFAULT_UPCASE=$(DEFAULT_UPCASE)
-endif
 ifdef DEFAULT_PROFILE
 	DEFS += -DDEFAULT_PROFILE=$(DEFAULT_PROFILE)
 endif
-ifdef DEFAULT_BASELEN
-	DEFS += -DDEFAULT_BASELEN=$(DEFAULT_BASELEN)
-endif
-ifdef DEFAULT_EXTLEN
-	DEFS += -DDEFAULT_EXTLEN=$(DEFAULT_EXTLEN)
+ifdef DEFAULT_UPCASE
+	DEFS += -DDEFAULT_UPCASE=$(DEFAULT_UPCASE)
 endif
 ifdef DEFAULT_ATTR
 	DEFS += -DDEFAULT_ATTR=$(DEFAULT_ATTR)

--- a/Makefile
+++ b/Makefile
@@ -10,22 +10,25 @@ APP_NAME := DeskLink2
 APP_LIB_DIR := $(PREFIX)/lib/$(NAME)
 APP_DOC_DIR := $(PREFIX)/share/doc/$(NAME)
 APP_VERSION := $(shell git describe --long 2>&-)
-#FB100_ROM := Brother_FB-100.rom # no use yet
-TPDD2_ROM := TANDY_26-3814.rom
 
-DEFAULT_BASIC_BYTE_MS := 8  # ms per byte in bootstrap
-DEFAULT_MODEL := 1          # 1=tpdd1  2=tpdd2  (TS-DOS directory support requires tpdd1)
-DEFAULT_OPERATION_MODE := 1 # 0=FDC-mode 1=Operation-mode
-DEFAULT_BAUD := 19200
-DEFAULT_RTSCTS := false
-DEFAULT_UPCASE := false
-DEFAULT_DOTPOS := 6    # default 6.2 filenames compatible with Floppy/TS-DOS/etc.
-DEFAULT_TILDES := true
-DEFAULT_ATTR := 0x46   # default attribute 'F' compatible with Floppy/TS-DOS/etc.
-RAW_ATTR := 0x20       # attr for "raw" mode, 0x00, 0x20, 0x46 are all plausible.
-XATTR_NAME := pdd.attr
-DEFAULT_DME_ROOT_LABEL := "0:    "
-DEFAULT_DME_PARENT_LABEL := "^     "
+# optional configurables
+#FB100_ROM := Brother_FB-100.rom # exists but not used
+TPDD2_ROM := TANDY_26-3814.rom
+#DEFAULT_BASIC_BYTE_MS := 8  # ms per byte in bootstrap
+#DEFAULT_MODEL := 1          # 1=tpdd1  2=tpdd2  (TS-DOS directory support requires tpdd1)
+#DEFAULT_OPERATION_MODE := 1 # 0=FDC-mode 1=Operation-mode
+#DEFAULT_BAUD := 19200
+#DEFAULT_RTSCTS := false
+#DEFAULT_UPCASE := false
+#DEFAULT_PROFILE := "k85" # k85 = Floppy/TS-DOS/etc - 6.2, dme, magic files
+#DEFAULT_BASELEN := 6    # default 6.2 filenames compatible with Floppy/TS-DOS/etc.
+#DEFAULT_EXTLEN := 2
+#DEFAULT_ATTR := 0x46   # default attribute 'F' compatible with Floppy/TS-DOS/etc.
+#RAW_ATTR := 0x20       # attr for "raw" mode, drive firmware fills unused fields with 0x20
+#DEFAULT_TILDES := true
+#XATTR_NAME := pdd.attr
+#TSDOS_ROOT_LABEL := "0:    "
+#TSDOS_PARENT_LABEL := "^     "
 
 CLIENT_LOADERS := \
 	clients/teeny/TINY.100 \
@@ -71,8 +74,8 @@ CLIENT_DOCS := \
 #	clients/power-dos/powr-d.txt
 
 DOCS := dl.do README.txt README.md LICENSE $(CLIENT_DOCS)
-SOURCES := dl.c dir_list.c
-HEADERS := dir_list.h constants.h
+SOURCES := dl.c dir_list.c xattr.c
+HEADERS := constants.h dir_list.h xattr.h
 
 ifeq ($(OS),Darwin)
  TTY_PREFIX := cu.usbserial
@@ -93,28 +96,63 @@ ifeq ($(OS),Windows_NT)
  CFLAGS += -D_WIN
 endif
 
-DEFINES := \
+DEFS = \
 	-DAPP_NAME=\"$(APP_NAME)\" \
 	-DAPP_VERSION=\"$(APP_VERSION)\" \
 	-DAPP_LIB_DIR=\"$(APP_LIB_DIR)\" \
 	-DTTY_PREFIX=\"$(TTY_PREFIX)\" \
-	-DDEFAULT_DME_ROOT_LABEL=\"$(DEFAULT_DME_ROOT_LABEL)\" \
-	-DDEFAULT_DME_PARENT_LABEL=\"$(DEFAULT_DME_PARENT_LABEL)\" \
 	-DTPDD2_ROM=\"$(TPDD2_ROM)\" \
-	-DDEFAULT_BASIC_BYTE_MS=$(DEFAULT_BASIC_BYTE_MS) \
-	-DDEFAULT_MODEL=$(DEFAULT_MODEL) \
-	-DDEFAULT_OPERATION_MODE=$(DEFAULT_OPERATION_MODE) \
-	-DDEFAULT_BAUD=$(DEFAULT_BAUD) \
-	-DDEFAULT_RTSCTS=$(DEFAULT_RTSCTS) \
-	-DDEFAULT_UPCASE=$(DEFAULT_UPCASE) \
-	-DDEFAULT_DOTPOS=$(DEFAULT_DOTPOS) \
-	-DDEFAULT_TILDES=$(DEFAULT_TILDES) \
-	-DDEFAULT_ATTR=$(DEFAULT_ATTR) \
-	-DRAW_ATTR=$(RAW_ATTR) \
-	-DXATTR_NAME=\"$(XATTR_NAME)\" \
-#	-DUSE_XATTR \
+	-DUSE_XATTR \
 #	-DPRINT_8BIT \
 #	-DNADSBOX_EXTENSIONS \
+
+ifdef TSDOS_ROOT_LABEL
+	DEFS += -DTSDOS_ROOT_LABEL=\"$(TSDOS_ROOT_LABEL)\"
+endif
+ifdef TSDOS_PARENT_LABEL
+	DEFS += -DTSDOS_PARENT_LABEL=\"$(TSDOS_PARENT_LABEL)\"
+endif
+ifdef DEFAULT_BASIC_BYTE_MS
+	DEFS += -DDEFAULT_BASIC_BYTE_MS=$(DEFAULT_BASIC_BYTE_MS)
+endif
+ifdef DEFAULT_MODEL
+	DEFS += -DDEFAULT_MODEL=$(DEFAULT_MODEL)
+endif
+ifdef DEFAULT_OPERATION_MODE
+	DEFS += -DDEFAULT_OPERATION_MODE=$(DEFAULT_OPERATION_MODE)
+endif
+ifdef DEFAULT_BAUD
+	DEFS += -DDEFAULT_BAUD=$(DEFAULT_BAUD)
+endif
+ifdef DEFAULT_RTSCTS
+	DEFS += -DDEFAULT_RTSCTS=$(DEFAULT_RTSCTS)
+endif
+ifdef DEFAULT_UPCASE
+	DEFS += -DDEFAULT_UPCASE=$(DEFAULT_UPCASE)
+endif
+ifdef DEFAULT_PROFILE
+	DEFS += -DDEFAULT_PROFILE=$(DEFAULT_PROFILE)
+endif
+ifdef DEFAULT_BASELEN
+	DEFS += -DDEFAULT_BASELEN=$(DEFAULT_BASELEN)
+endif
+ifdef DEFAULT_EXTLEN
+	DEFS += -DDEFAULT_EXTLEN=$(DEFAULT_EXTLEN)
+endif
+ifdef DEFAULT_ATTR
+	DEFS += -DDEFAULT_ATTR=$(DEFAULT_ATTR)
+endif
+ifdef RAW_ATTR
+	DEFS += -DRAW_ATTR=$(RAW_ATTR)
+endif
+ifdef DEFAULT_TILDES
+	DEFS += -DDEFAULT_TILDES=$(DEFAULT_TILDES)
+endif
+ifdef XATTR_NAME
+	DEFS += -DXATTR_NAME=\"$(XATTR_NAME)\"
+endif
+
+DEFINES := $(DEFS)
 
 ifdef DEBUG
  CFLAGS += -g
@@ -123,7 +161,7 @@ endif
 .PHONY: all
 all: $(NAME)
 
-$(NAME): $(SOURCES) $(HEADERS)
+$(NAME): Makefile $(SOURCES) $(HEADERS)
 	$(CC) $(CFLAGS) $(CXXFLAGS) $(DEFINES) $(SOURCES) $(LDLIBS) -o $(@)
 
 install: $(NAME) $(CLIENT_LOADERS) $(LIB_OTHER) $(DOCS)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Docs from the past versions of this program. They don't exactly match this versi
 
 ### List all available TPDD client installers, and then bootstrap one of them
 ```
-$ dl -l
+$ dl -b
 $ dl -vb TS-DOS.100
 ```
 
@@ -221,11 +221,10 @@ Tested on Linux, [Mac](ref/mac.md), [FreeBSD](ref/freebsd.md), and [Windows](ref
 * Fake sector 0 based on the files in the current share path so that if a client tries to read the FCB table directly it works.
 * Fake entire disk image in ram based on current share path files. Option to save the image as long as we're there.
 
-## New Feature Testing
-[real attr handling using xattr](ref/xattr.md)
+## Latest Changes
+* [real attr handling using xattr](ref/xattr.md) - enabled by default now
 
-Enable by building with `-DUSE_XATTR`  
-`$ make clean all CXXFLAGS=-DUSE_XATTR && sudo make install`
+* client compatibility profiles
 
 ## History / Credits
 [DeskLink for ms-dos](https://ftp.whtech.com/club100/com/dl-arc.exe.gz) 1987 Travelling Software  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Usage: ./dl [options] [tty_device] [share_path]
 Options     Description (default setting)
  -a attr    Attribute - default attr byte used when no xattr (F)
  -b file    Bootstrap - send loader file to client - empty for help
- -c compat  Client compat profile - empty for help (k85)
+ -c profile Client compatibility profile - empty for help (k85)
  -d tty     Serial device connected to the client (ttyUSB*)
  -e bool    TS-DOS Subdirectories (true)
  -g         Getty mode - run as daemon

--- a/README.md
+++ b/README.md
@@ -14,26 +14,28 @@ $ sudo make uninstall
 ## Manual
 ```
 $ dl -h
-DeskLink2 v2.1.001-30-ge4936fd
+DeskLink2 v2.1.001-33-g1f5ccb2
 
 Usage: ./dl [options] [tty_device] [share_path]
 
-Options     Description (default setting)
- -a attr    Attribute - default attr byte used when no xattr (F)
- -b file    Bootstrap - send loader file to client - empty for help
- -c profile Client compatibility profile - empty for help (k85)
- -d tty     Serial device connected to the client (ttyUSB*)
- -e bool    TS-DOS Subdirectories (true)
- -g         Getty mode - run as daemon
- -h         Print this help
- -i file    Disk image filename for raw sector access - empty for help
- -m #       Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
- -p dir     Path - /path/to/dir with files to be served (./)
- -r         RTS/CTS hardware flow control (false)
- -s #       Speed - serial port baud rate (19200)
- -u         Uppercase all filenames (false)
- -v         Verbosity - more v's = more verbose
- -z #       Milliseconds per byte for bootstrap (8)
+Options      Description... (default setting)
+ -a attr     Attribute - default attr byte used when no xattr (F)
+ -b file     Bootstrap - send loader file to client - empty for help
+ -c profile  Client compatibility profile - empty for help (k85)
+ -d tty      Serial device connected to the client (ttyUSB*)
+ -e bool     TS-DOS Subdirectories (true)
+ -g          Getty mode - run as daemon
+ -h          Print this help
+ -i file     Disk image filename for raw sector access - empty for help
+ -m #        Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
+ -p dir      Path - /path/to/dir with files to be served (./)
+ -r          RTS/CTS hardware flow control (false)
+ -s #        Speed - serial port baud rate (19200)
+ -u          Uppercase all filenames (false)
+ -~ bool     Truncated filenames end in '~' (true)
+ -v          Verbosity - more v's = more verbose
+ -z #        Milliseconds per byte for bootstrap (8)
+ -^ #        Dump config and exit
 
 The 1st non-option argument is another way to specify the tty device.
 The 2nd non-option argument is another way to specify the share path.
@@ -84,7 +86,7 @@ $
 
 ```
 $ ./dl -c
-DeskLink2 v2.1.001-30-ge4936fd
+DeskLink2 v2.1.001-33-g1f5ccb2
 "-c" requires a value
 
 Client Compatibility Profiles
@@ -94,11 +96,18 @@ NAME	LEN	LEN	FNAMES	BYTE	DIRS	FILES	CASE
 -------------------------------------------------------------
 raw	0	0	false	' '	false	false	false
 k85	6	2	true	'F'	true	true	
-wp2	8	2	true	'F'	false	false	
-cpm	8	3	false	'F'	false	false	
+wp2	8	2	true	'F'	false	false	false
+cpm	8	3	false	'F'	false	false	false
 rexcpm	6	2	true	'F'	false	false	true
-z88	12	3	false	'F'	false	false	
+z88	12	3	false	'F'	false	false	false
 st	6	2	true	'F'	false	false	
+
+Example: "-c cpm" sets filenames to 8.3 without padding or upcase.
+
+May also use "-c ##.##" to set an arbitrary filename pattern
+with other parameters set same as "raw". Example: -c 16.0 
+
+Filenames are limited to 24 bytes total, the hardware limit in a real drive.
 
 $ 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ sudo make uninstall
 $ dl -h
 DeskLink2 v2.2.001-1-gce946d5
 
-Usage: ./dl [options] [tty_device] [share_path]
+Usage: dl [options] [tty_device] [share_path]
 
 Options      Description... (default setting)
  -a attr     Attribute - default attr byte used when no xattr (F)
@@ -44,17 +44,17 @@ TPDD2 mode accepts a 2nd share path for bank 1.
 "bool" accepts case-insensitive: on off 0 1 y n t f yes no true false
 
 Examples:
-   $ ./dl
-   $ ./dl ttyUSB1
-   $ ./dl -v -p ~/Downloads/REX
-   $ ./dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
-   $ ./dl -m2 -p /tmp/bank0 -p /tmp/bank1
+   $ dl
+   $ dl ttyUSB1
+   $ dl -v -p ~/Downloads/REX
+   $ dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
+   $ dl -m2 -p /tmp/bank0 -p /tmp/bank1
 
 $
 ```
 
 ```
-$ ./dl -b
+$ dl -b
 DeskLink2 v2.2.001-1-gce946d5
 "-b" requires a value
 
@@ -79,16 +79,16 @@ and then in /usr/local/lib/dl
 
 Examples:
 
-   ./dl -b TS-DOS.100
-   ./dl -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100
-   ./dl -vb rxcini.DO && ./dl -v
-   ./dl -v -i Sardine_American_English.pdd1
+   dl -b TS-DOS.100
+   dl -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100
+   dl -vb rxcini.DO && ./dl -v
+   dl -v -i Sardine_American_English.pdd1
 
 $ 
 ```
 
 ```
-$ ./dl -c
+$ dl -c
 DeskLink2 v2.2.001-1-gce946d5
 "-c" requires a value
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ TPDD2 mode accepts a 2nd share path for bank 1.
 Examples:
    $ ./dl
    $ ./dl ttyUSB1
-   $ ./dl -vu -p ~/Downloads/REX
+   $ ./dl -v -p ~/Downloads/REX
    $ ./dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
    $ ./dl -m2 -p /tmp/bank0 -p /tmp/bank1
 
@@ -81,8 +81,8 @@ Examples:
 
    ./dl -b TS-DOS.100
    ./dl -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100
-   ./dl -vb rxcini.DO && ./dl -vu
-   ./dl -vu -i Sardine_American_English.pdd1
+   ./dl -vb rxcini.DO && ./dl -v
+   ./dl -v -i Sardine_American_English.pdd1
 
 $ 
 ```
@@ -125,8 +125,8 @@ Docs from the past versions of this program. They don't exactly match this versi
 
 ## Examples:
 
-### Run the TPDD server, verbose, upcase, serving files from the current directory
-`$ dl -vu`
+### Run the TPDD server, verbose, serving files from the current directory
+`$ dl -v`
 
 ### List all available TPDD client installers, and then bootstrap one of them
 ```
@@ -139,7 +139,7 @@ $ dl -vb TS-DOS.100
 ([Full directions for REXCPM](ref/REXCPM.md))
 
 ### Update a [REX#](http://bitchin100.com/wiki/index.php?title=REXsharp)
-`$ dl -vb 'rx#u1.do' && dl -vu`
+`$ dl -vb 'rx#u1.do' && dl -v`
 
 ## "Magic Files" / Ultimate ROM II / TSLOAD
 There is a short list of filenames that are specially recognized:  
@@ -218,7 +218,7 @@ Example using co2ba as part of bootstrapping a REX Classic:
 $ wget https://www.bitchin100.com/wiki/images/3/38/R49_M100T102_260_rebuild.zip
 $ unzip R49_M100T102_260_rebuild.zip
 $ co2ba rf149.co call >rf149.do
-$ dl -vb rf149.do && dl -vu
+$ dl -vb rf149.do && dl -v
 ```
 
 ## OS Compatibility

--- a/README.md
+++ b/README.md
@@ -14,33 +14,34 @@ $ sudo make uninstall
 ## Manual
 ```
 $ dl -h
-DeskLink2 v2.2.001-0-g7b928ff
+DeskLink2 v2.2.001-1-gce946d5
 
 Usage: ./dl [options] [tty_device] [share_path]
 
 Options      Description... (default setting)
  -a attr     Attribute - default attr byte used when no xattr (F)
  -b file     Bootstrap - send loader file to client - empty for help
- -c profile  Client compatibility profile - empty for help (k85)
+ -c profile  Client compatibility profile (k85) - empty for help
  -d tty      Serial device connected to the client (ttyUSB*)
- -e bool     TS-DOS Subdirectories (true)
+ -e bool     TS-DOS Subdirectories (on) - TPDD1-only
+ -f          Start in FDC mode - TPDD1-only
  -g          Getty mode - run as daemon
  -h          Print this help
  -i file     Disk image filename for raw sector access - empty for help
- -m #        Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
+ -m 1|2      Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
  -p dir      Path - /path/to/dir with files to be served (./)
- -r          RTS/CTS hardware flow control (false)
+ -r bool     RTS/CTS hardware flow control (off)
  -s #        Speed - serial port baud rate (19200)
- -u          Uppercase all filenames (false)
- -~ bool     Truncated filenames end in '~' (true)
- -v          Verbosity - more v's = more verbose
- -z #        Milliseconds per byte for bootstrap (8)
- -^ #        Dump config and exit
+ -u          Uppercase all filenames (off)
+ -~ bool     Truncated filenames end in '~' (on)
+ -v          Verbosity - more v's = more verbose, both activity & help
+ -z #        Sleep # ms per byte in bootstrap (8)
+ -^          Dump config and exit
 
 The 1st non-option argument is another way to specify the tty device.
 The 2nd non-option argument is another way to specify the share path.
 TPDD2 mode accepts a 2nd share path for bank 1.
-TPDD2 mode does not support TS-DOS dfirectories.
+"bool" accepts case-insensitive: on off 0 1 y n t f yes no true false
 
 Examples:
    $ ./dl
@@ -49,17 +50,17 @@ Examples:
    $ ./dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
    $ ./dl -m2 -p /tmp/bank0 -p /tmp/bank1
 
-
 $
 ```
 
 ```
 $ ./dl -b
-DeskLink2 v2.2.001-0-g7b928ff
+DeskLink2 v2.2.001-1-gce946d5
 "-b" requires a value
+
 Available support files in /usr/local/lib/dl
 
-Loader files for use with -b:
+Bootstrap/Loader files for use with -b :
 -----------------------------
 TRS-80 Model 100/102 : DSKMGR.100 TSLOAD.100 TS-DOS.100 TINY.100 D.100 TEENY.100 PAKDOS.100
 TANDY Model 200      : DSKMGR.200 TSLOAD.200 TS-DOS.200 PAKDOS.200 TEENY.200
@@ -67,14 +68,15 @@ NEC PC-8201/PC-8300  : TEENY.NEC TS-DOS.NEC
 Kyotronic KC-85      : DSKMGR.K85 Disk_Power.K85
 Olivetti M-10        : TEENY.M10 DSKMGR.M10
 
-Disk image files for use with -i:
+Disk image files for use with -i :
 ---------------------------------
 Sardine_American_English.pdd1
 Disk_Power.K85.pdd1
 
 
-Filenames given without any path are searched from /usr/local/lib/dl
-as well as the current directory.
+Filenames are searched in the current directory first,
+and then in /usr/local/lib/dl
+
 Examples:
 
    ./dl -b TS-DOS.100
@@ -87,28 +89,26 @@ $
 
 ```
 $ ./dl -c
-DeskLink2 v2.2.001-0-g7b928ff
+DeskLink2 v2.2.001-1-gce946d5
 "-c" requires a value
 
-Client Compatibility Profiles
+help for Client Compatibility Profiles
 
-PROFILE	BASE	EXT	PAD	ATTR	TS-DOS	MAGIC	UP
-NAME	LEN	LEN	FNAMES	BYTE	DIRS	FILES	CASE
+usage:
+ -c name    use profile <name> - (default: "k85")
+ -c #.#     "raw" with filenames truncated to #.# & attr='F'
+ -c #.#p    "#.#" fixed-length space-padded
+ -v -c      more help
+
+NAME	BASE	EXT	PAD	ATTR	DME	TSLOAD	UPCASE
 -------------------------------------------------------------
-raw	0	0	false	' '	false	false	false
-k85	6	2	true	'F'	true	true	
-wp2	8	2	true	'F'	false	false	false
-cpm	8	3	false	'F'	false	false	false
-rexcpm	6	2	true	'F'	false	false	true
-z88	12	3	false	'F'	false	false	false
-st	6	2	true	'F'	false	false	
-
-Example: "-c cpm" sets filenames to 8.3 without padding or upcase.
-
-May also use "-c ##.##" to set an arbitrary filename pattern
-with other parameters set same as "raw". Example: -c 16.0 
-
-Filenames are limited to 24 bytes total, the hardware limit in a real drive.
+raw	0	0	off	' '	off	off	off
+k85	6	2	on	'F'	on	on	off
+wp2	8	2	on	'F'	off	off	off
+cpm	8	3	off	'F'	off	off	off
+rexcpm	6	2	on	'F'	off	off	on
+z88	12	3	off	'F'	off	off	off
+st	6	2	on	'F'	off	off	off
 
 $ 
 ```
@@ -230,6 +230,7 @@ Tested on Linux, [Mac](ref/mac.md), [FreeBSD](ref/freebsd.md), and [Windows](ref
 * Figure out and emulate more of the special memory addresses accessible in tpdd2 mode. We already do some.
 * Fake sector 0 based on the files in the current share path so that if a client tries to read the FCB table directly it works.
 * Fake entire disk image in ram based on current share path files. Option to save the image as long as we're there.
+* -j 1111 to emulate the jumper settings
 
 ## Latest Changes
 * [real attr handling using xattr](ref/xattr.md) - enabled by default now

--- a/README.md
+++ b/README.md
@@ -14,28 +14,26 @@ $ sudo make uninstall
 ## Manual
 ```
 $ dl -h
-DeskLink2 v2.1.001-19-g14a2925
+DeskLink2 v2.1.001-30-ge4936fd
 
-Usage: dl [options] [tty_device] [share_path]
+Usage: ./dl [options] [tty_device] [share_path]
 
 Options     Description (default setting)
-   -0       Raw mode - no filename munging, attr = ' '
-   -a c     Attribute - default attr byte used when no xattr (F)
-   -b file  Bootstrap - send loader file to client
-   -d tty   Serial device connected to the client (ttyUSB*)
-   -n       Disable TS-DOS directories (enabled)
-   -g       Getty mode - run as daemon
-   -h       Print this help
-   -i file  Disk image filename for raw sector access
-   -l       List loader files and show bootstrap help
-   -m #     Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
-   -p dir   Path - /path/to/dir with files to be served (./)
-   -r       RTS/CTS hardware flow control (false)
-   -s #     Speed - serial port baud rate (19200)
-   -u       Uppercase all filenames (false)
-   -v       Verbosity - more v's = more verbose
-   -w       WP-2 mode - 8.2 filenames for TANDY WP-2
-   -z #     Milliseconds per byte for bootstrap (8)
+ -a attr    Attribute - default attr byte used when no xattr (F)
+ -b file    Bootstrap - send loader file to client - empty for help
+ -c compat  Client compat profile - empty for help (k85)
+ -d tty     Serial device connected to the client (ttyUSB*)
+ -e bool    TS-DOS Subdirectories (true)
+ -g         Getty mode - run as daemon
+ -h         Print this help
+ -i file    Disk image filename for raw sector access - empty for help
+ -m #       Model - 1 = FB-100/TPDD1, 2 = TPDD2 (1)
+ -p dir     Path - /path/to/dir with files to be served (./)
+ -r         RTS/CTS hardware flow control (false)
+ -s #       Speed - serial port baud rate (19200)
+ -u         Uppercase all filenames (false)
+ -v         Verbosity - more v's = more verbose
+ -z #       Milliseconds per byte for bootstrap (8)
 
 The 1st non-option argument is another way to specify the tty device.
 The 2nd non-option argument is another way to specify the share path.
@@ -43,26 +41,27 @@ TPDD2 mode accepts a 2nd share path for bank 1.
 TPDD2 mode does not support TS-DOS dfirectories.
 
 Examples:
-   $ dl
-   $ dl ttyUSB1
-   $ dl -vu -p ~/Downloads/REX
-   $ dl -w /dev/cu.usbserial-AB0MQNN1 ~/Documents/wp2
-   $ dl -m2 -p /tmp/bank0 -p /tmp/bank1
+   $ ./dl
+   $ ./dl ttyUSB1
+   $ ./dl -vu -p ~/Downloads/REX
+   $ ./dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
+   $ ./dl -m2 -p /tmp/bank0 -p /tmp/bank1
 
 $
 ```
 
 ```
-$ dl -l
-DeskLink2 v2.1.001-19-g14a2925
+$ ./dl -b
+DeskLink2 v2.1.001-30-ge4936fd
+"-b" requires a value
 Available support files in /usr/local/lib/dl
 
 Loader files for use with -b:
 -----------------------------
-TRS-80 Model 100/102 : DSKMGR.100 TINY.100 D.100 TEENY.100 TSLOAD.100 TS-DOS.100 PAKDOS.100
+TRS-80 Model 100/102 : PAKDOS.100 TINY.100 D.100 TEENY.100 DSKMGR.100 TSLOAD.100 TS-DOS.100
 TANDY Model 200      : TEENY.200 DSKMGR.200 TSLOAD.200 TS-DOS.200 PAKDOS.200
-NEC PC-8201/PC-8300  : TEENY.NEC TS-DOS.NEC
-Kyotronic KC-85      : DSKMGR.K85 Disk_Power.K85
+NEC PC-8201/PC-8300  : TS-DOS.NEC TEENY.NEC
+Kyotronic KC-85      : Disk_Power.K85 DSKMGR.K85
 Olivetti M-10        : TEENY.M10 DSKMGR.M10
 
 Disk image files for use with -i:
@@ -75,13 +74,35 @@ Filenames given without any path are searched from /usr/local/lib/dl
 as well as the current directory.
 Examples:
 
-   dl -b TS-DOS.100
-   dl -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100
-   dl -vb rxcini.DO && dl -vu
-   dl -vu -i Sardine_American_English.pdd1
+   ./dl -b TS-DOS.100
+   ./dl -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100
+   ./dl -vb rxcini.DO && ./dl -vu
+   ./dl -vu -i Sardine_American_English.pdd1
 
 $ 
 ```
+
+```
+$ ./dl -c
+DeskLink2 v2.1.001-30-ge4936fd
+"-c" requires a value
+
+Client Compatibility Profiles
+
+PROFILE	BASE	EXT	PAD	ATTR	TS-DOS	MAGIC	UP
+NAME	LEN	LEN	FNAMES	BYTE	DIRS	FILES	CASE
+-------------------------------------------------------------
+raw	0	0	false	' '	false	false	false
+k85	6	2	true	'F'	true	true	
+wp2	8	2	true	'F'	false	false	
+cpm	8	3	false	'F'	false	false	
+rexcpm	6	2	true	'F'	false	false	true
+z88	12	3	false	'F'	false	false	
+st	6	2	true	'F'	false	false	
+
+$ 
+```
+
 
 Several of the above settings can alternatively be supplied via environment variables, as well as a few other [hacky extra options](ref/advanced_options.txt)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ sudo make uninstall
 ## Manual
 ```
 $ dl -h
-DeskLink2 v2.1.001-33-g1f5ccb2
+DeskLink2 v2.2.001-0-g7b928ff
 
 Usage: ./dl [options] [tty_device] [share_path]
 
@@ -49,21 +49,22 @@ Examples:
    $ ./dl -c wp2 /dev/cu.usbserial-AB0MQNN1 "~/Documents/WP-2 Files"
    $ ./dl -m2 -p /tmp/bank0 -p /tmp/bank1
 
+
 $
 ```
 
 ```
 $ ./dl -b
-DeskLink2 v2.1.001-30-ge4936fd
+DeskLink2 v2.2.001-0-g7b928ff
 "-b" requires a value
 Available support files in /usr/local/lib/dl
 
 Loader files for use with -b:
 -----------------------------
-TRS-80 Model 100/102 : PAKDOS.100 TINY.100 D.100 TEENY.100 DSKMGR.100 TSLOAD.100 TS-DOS.100
-TANDY Model 200      : TEENY.200 DSKMGR.200 TSLOAD.200 TS-DOS.200 PAKDOS.200
-NEC PC-8201/PC-8300  : TS-DOS.NEC TEENY.NEC
-Kyotronic KC-85      : Disk_Power.K85 DSKMGR.K85
+TRS-80 Model 100/102 : DSKMGR.100 TSLOAD.100 TS-DOS.100 TINY.100 D.100 TEENY.100 PAKDOS.100
+TANDY Model 200      : DSKMGR.200 TSLOAD.200 TS-DOS.200 PAKDOS.200 TEENY.200
+NEC PC-8201/PC-8300  : TEENY.NEC TS-DOS.NEC
+Kyotronic KC-85      : DSKMGR.K85 Disk_Power.K85
 Olivetti M-10        : TEENY.M10 DSKMGR.M10
 
 Disk image files for use with -i:
@@ -86,7 +87,7 @@ $
 
 ```
 $ ./dl -c
-DeskLink2 v2.1.001-33-g1f5ccb2
+DeskLink2 v2.2.001-0-g7b928ff
 "-c" requires a value
 
 Client Compatibility Profiles

--- a/constants.h
+++ b/constants.h
@@ -247,10 +247,20 @@ static const uint16_t FDC_LOGICAL_SECTOR_SIZE[7] = {64,80,128,256,512,1024,1280}
 #define OPR_CMD_SYNC 0x5A
 #define FDC_CMD_EOL  0x0D
 
-// compatibility modes
-#define DOT_FLOPPY  6
-#define DOT_WP2     8
+// drive operating modes
 #define MODE_OPR    1
 #define MODE_FDC    0
+
+#ifdef RAW_ATTR
+#define ATTR_RAW RAW_ATTR
+#else
+#define ATTR_RAW 0x20 // space - drive firmware fills unused with 0x20
+#endif
+
+#ifdef DEFAULT_ATTR
+#define ATTR_DEF DEFAULT_ATTR
+#else
+#define ATTR_DEF 0x46 // F - almost all clients on all platforms hardcode F
+#endif
 
 #endif // PDD_CONSTANTS_H

--- a/dir_list.c
+++ b/dir_list.c
@@ -23,6 +23,7 @@ MA 02111, USA.
 #include <strings.h>
 #include <string.h>
 #include <ctype.h>
+
 #include "dir_list.h"
 
 static uint16_t allocated;
@@ -33,9 +34,9 @@ static FILE_ENTRY* tblp = 0;
 static FILE_ENTRY* current_record(void);
 
 int file_list_init() {
-	tblp = malloc(sizeof(FILE_ENTRY)*FEQ);
+	tblp = malloc(sizeof(FILE_ENTRY)*DIRENTS);
 	if (!tblp) return -1;
-	allocated = FEQ;
+	allocated = DIRENTS;
 	ndx = 0;
 	cur = 0;
 	return 0;
@@ -53,14 +54,14 @@ int file_list_cleanup() {
 void file_list_clear_all() {
 	cur = ndx = 0;
 }
-   
+
 int add_file(FILE_ENTRY* fe) {
-	/* allocate FEQ more records if out of space */
+	/* allocate DIRENTS more records if out of space */
 	if (ndx >= allocated) {
 		/* resize the array */
-		tblp = realloc(tblp, (allocated+FEQ)*sizeof(FILE_ENTRY));
+		tblp = realloc(tblp, (allocated+DIRENTS)*sizeof(FILE_ENTRY));
 		if (!tblp) return -1;
-		allocated += FEQ;
+		allocated += DIRENTS;
 	}
 
 	/* reference the entry */

--- a/dir_list.h
+++ b/dir_list.h
@@ -24,10 +24,7 @@ MA 02111, USA.
 #include <stdint.h>
 #include "constants.h"
 
-#define FEQ DIRENTS // number of FILE_ENTRYs to malloc for at a time
-
-typedef struct
-{
+typedef struct {
 	char     client_fname[TPDD_FILENAME_LEN+1];
 	char     local_fname[LOCAL_FILENAME_MAX+1];
 	uint8_t  attr;

--- a/dl.c
+++ b/dl.c
@@ -162,15 +162,17 @@ const char * magic_files[] = {
 };
 
 // client compatibility profiles
-// REXCPM native is cpm, but import & export forces 6.2 upcase
-// Cambridge Z88 native is 12.3, not sure what DISCMNGR or DISC_RBL actually does
-// Atari ST native is cpm, but PDDOS limits to 6.2
-// No xenix client exists probably, but it would be 14.0
+// kc-85 platform can use lowercase filenames just fine, but at least both both
+// TS-DOS and TEENY convert to uppercase in places, so upcase to avoid the battle.
+// REXCPM native is cpm, but import & export forces 6.2 upcase.
+// Cambridge Z88 native is 12.3, not sure what DISCMNGR or DISC_RBL actually does.
+// Atari ST native is cpm, but PDDOS limits to 6.2 .
+// No xenix client exists probably, but it would be 14.0 .
 //	{ "xenix",  14, 0, false, ATTR_RAW, false, false, false }
 //     id,   base, ext, pad,    attr,    dme,  magic, upcase
 #define CLIENT_PROFILES { \
 	{ "raw",    0,  0, false, ATTR_RAW, false, false, false }, \
-	{ "k85",    6,  2, true,  ATTR_DEF, true,  true,  false }, \
+	{ "k85",    6,  2, true,  ATTR_DEF, true,  true,  true  }, \
 	{ "wp2",    8,  2, true,  ATTR_DEF, false, false, false }, \
 	{ "cpm",    8,  3, false, ATTR_DEF, false, false, false }, \
 	{ "rexcpm", 6,  2, true,  ATTR_DEF, false, false, true  }, \
@@ -2464,8 +2466,8 @@ void show_bootstrap_help() {
 		"Examples:\n\n"
 		"   %1$s -b TS-DOS.100\n"
 		"   %1$s -b ~/Documents/LivingM100SIG/Lib-03-TELCOM/XMDPW5.100\n"
-		"   %1$s -vb rxcini.DO && %1$s -vu\n"
-		"   %1$s -vu -i Sardine_American_English.pdd1\n\n"
+		"   %1$s -vb rxcini.DO && %1$s -v\n"
+		"   %1$s -v -i Sardine_American_English.pdd1\n\n"
 	,args[0],app_lib_dir);
 }
 
@@ -2646,7 +2648,7 @@ void show_main_help() {
 		"Examples:\n"
 		"   $ %1$s\n"
 		"   $ %1$s ttyUSB1\n"
-		"   $ %1$s -vu -p ~/Downloads/REX\n"
+		"   $ %1$s -v -p ~/Downloads/REX\n"
 		"   $ %1$s -c wp2 /dev/cu.usbserial-AB0MQNN1 \"~/Documents/WP-2 Files\"\n"
 		"   $ %1$s -m2 -p /tmp/bank0 -p /tmp/bank1\n"
 		"\n"

--- a/dl.c
+++ b/dl.c
@@ -1332,32 +1332,6 @@ void get_fdc_cmd() {
 //  OPERATION MODE
 //
 
-/*
-#define MIN(a,b)    (((a)<(b))?(a):(b))
-#define MAX(a,b)    (((a)>(b))?(a):(b))
-#define MAX3(a,b,c) (((a)>(b))?(((a)>(c))?(a):(c)):(((b)>(c))?(b):(c)))
-#define MIN3(a,b,c) (((a)<(b))?(((a)<(c))?(a):(c)):(((b)<(c))?(b):(c)))
-
-static inline int min(const int a, const int b) {
-    return a < b ? a : b;
-}
-static inline int max(const int a, const int b) {
-    return a > b ? a : b;
-}
-static inline long minl(const long a, const long b) {
-    return a < b ? a : b;
-}
-static inline long maxl(const long a, const long b) {
-    return a > b ? a : b;
-}
-static inline long long minll(const long long a, const long long b) {
-    return a < b ? a : b;
-}
-static inline long long maxll(const long long a, const long long b) {
-    return a > b ? a : b;
-}
-*/
-
 FILE_ENTRY* make_file_entry(char* namep, uint8_t attr, uint16_t len, char flags) {
 	dbg(3,"%s(\"%s\")\n",__func__,namep);
 	static FILE_ENTRY f;
@@ -1476,9 +1450,11 @@ int read_next_dirent(DIR* dir,int m) {
 			if (strlen(dire->d_name)>LOCAL_FILENAME_MAX) continue; // skip long filenames
 		}
 
+		// TODO - make this configurable
 		// If filesize is too large for the tpdd 16 bit size field, then say
-		// size=0 but allow the file to be accessed, because cpmupd.CO for
-		// REXCPM violates the tpdd protocol to load a large CP/M disk image.
+		// size=0 but allow the file to be accessed.
+		// A real drive does NOT do this, but REXCPM cpmupd.CO
+		// violates the tpdd protocol to load a large CP/M disk image.
 		if (st.st_size>UINT16_MAX) st.st_size=0;
 
 		uint8_t attr = default_attr;
@@ -2796,7 +2772,7 @@ int main(int argc, char** argv) {
 	// show the directory listing locally even before any directory list
 	// commands, so that a user with no client-side display like TEENY, REX
 	// rom image loading, REXCPM rxcini setup, etc can see what filenames are
-	// available to load and their exact spelling from the tpdd client side.
+	// available to load, and their exact spelling from the tpdd client side.
 	if (debug) update_file_list(NO_RET);
 
 	// process commands forever

--- a/xattr.c
+++ b/xattr.c
@@ -1,0 +1,64 @@
+// Instead of hard-coding 'F' for the ATTR field at all times,
+// store the actual attr byte from the client in xattr.
+
+// dl.c always sets attr first (default or from client) then calls one of these.
+// If !USE_XATTR, then these are all no-op and attr simply left unchanged.
+// If USE_XATTR, then these may or may not copy xattr to attr, or attr to xattr,
+// depending on get vs set and depending on if the xattr exists.
+
+#ifdef USE_XATTR
+
+#if defined(__FreeBSD__)
+#include <sys/extattr.h>
+#else
+#include <sys/xattr.h>
+#endif
+
+#include "xattr.h"
+
+#ifndef XATTR_NAME
+#define XATTR_NAME "pdd.attr"
+#endif
+
+const char* xattr_name =
+#if defined(__linux__)
+	 "user." XATTR_NAME
+#elif defined(__APPLE__)
+	XATTR_NAME "#S"
+#else
+	XATTR_NAME
+#endif
+;
+
+void dl_getxattr(const char* path, uint8_t* value) {
+#if defined(__linux__)
+	getxattr(path, xattr_name, value, 1);
+#elif defined(__APPLE__)
+	getxattr(path, xattr_name, value, 1, 0, 0);
+#elif defined(__FreeBSD__)
+	extattr_get_file(path, EXTATTR_NAMESPACE_USER, xattr_name, value, 1);
+#endif
+}
+
+void dl_fgetxattr(int fd, uint8_t* value) {
+#if defined(__linux__)
+	fgetxattr(fd, xattr_name, value, 1);
+#elif defined(__APPLE__)
+	fgetxattr(fd, xattr_name, value, 1, 0, 0);
+#elif defined(__FreeBSD__)
+	extattr_get_fd(fd, EXTATTR_NAMESPACE_USER, xattr_name, value, 1);
+#endif
+}
+
+void dl_fsetxattr(int fd, const uint8_t* value) {
+#if defined(__linux__)
+	fsetxattr(fd, xattr_name, value, 1, 0);
+#elif defined(__APPLE__)
+	fsetxattr(fd, xattr_name, value, 1, 0, 0);
+#elif defined(__FreeBSD__)
+	extattr_set_fd(fd, EXTATTR_NAMESPACE_USER, xattr_name, value, 1);
+#endif
+}
+
+#endif // USE_XATTR
+

--- a/xattr.h
+++ b/xattr.h
@@ -1,0 +1,22 @@
+#ifndef PDD_XATTR_H
+#define PDD_XATTR_H
+
+#include <stdint.h>
+
+#ifdef USE_XATTR
+
+extern const char* xattr_name;
+
+void dl_getxattr (const char* path, uint8_t* value);
+void dl_fgetxattr (int fd, uint8_t* value);
+void dl_fsetxattr (int fd, const uint8_t* value);
+
+#else // USE_XATTR
+
+#define dl_getxattr(x,y)
+#define dl_fgetxattr(x,y)
+#define dl_fsetxattr(x,y)
+
+#endif // USE_XATTR
+
+#endif // PDD_XATTR_H


### PR DESCRIPTION
- profiles
- fix make_file_entry(), local `xxxxxx.x` would come out `xxxxxx. x`
- enable "real" attr in xattr by default